### PR TITLE
Expose Kafka consumer offset reset policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Configure your Kafka services in '**appsettings.json**' as follows:
     "GroupId": "my-consumer-group",
     "MakeGroupUnique": false,
     "AutoCommit": true,
+    "AutoOffsetReset": "Error",
     "Topics": ["topic1", "topic2"]
   }
 }
@@ -84,6 +85,7 @@ These sections define the settings for your Kafka producer and consumer, includi
 + **GroupId**: The name of the consumer group this consumer belongs to. Consumer groups allow a group of consumers to cooperate in consuming the messages.
 + **MakeGroupUnique**: When set to true, appends a unique identifier (timestamp) to the GroupId, creating a unique consumer group on every run.
 + **AutoCommit**: If set to true, the consumer's offset will be periodically committed in the background.
++ **AutoOffsetReset**: Optional Confluent.Kafka policy (`Earliest`, `Latest`, or `Error`) used when no initial offset exists or the committed offset is unavailable. Omit it to preserve the existing client default. Archival consumers should prefer `Error` so retention loss fails visibly instead of silently skipping data.
 + **Topics**: An array of topics this consumer should subscribe to.
 
 ## Implementing Services

--- a/src/Config/KafkaConsumerConfig.cs
+++ b/src/Config/KafkaConsumerConfig.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Confluent.Kafka;
 namespace am.kon.packages.services.kafka.Config
 {
     /// <summary>
@@ -40,6 +41,13 @@ namespace am.kon.packages.services.kafka.Config
         /// Autocommit acnowledgement of Kafka message consuming
         /// </summary>
         public bool AutoCommit { get; set; }
+
+        /// <summary>
+        /// Defines how the consumer behaves when there is no initial offset or
+        /// the committed offset is no longer available on the broker.
+        /// When omitted, the underlying Confluent.Kafka default is preserved.
+        /// </summary>
+        public AutoOffsetReset? AutoOffsetReset { get; set; }
 
         /// <summary>
         /// Name of topics to subscribe to

--- a/src/Extensions/KafkaConsumerConfigExtensions.cs
+++ b/src/Extensions/KafkaConsumerConfigExtensions.cs
@@ -22,11 +22,11 @@ namespace am.kon.packages.services.kafka.Extensions
                 MessageMaxBytes = kafkaConsumerConfig.MessageMaxBytes,
                 SocketTimeoutMs = kafkaConsumerConfig.SocketTimeoutMs,
                 GroupId = kafkaConsumerConfig.GroupId,
-                EnableAutoCommit = kafkaConsumerConfig.AutoCommit
+                EnableAutoCommit = kafkaConsumerConfig.AutoCommit,
+                AutoOffsetReset = kafkaConsumerConfig.AutoOffsetReset
             };
 
             return res;
         }
     }
 }
-

--- a/tests/am.kon.packages.services.kafka.tests/KafkaConsumerConfigExtensionsTests.cs
+++ b/tests/am.kon.packages.services.kafka.tests/KafkaConsumerConfigExtensionsTests.cs
@@ -1,0 +1,44 @@
+using am.kon.packages.services.kafka.Config;
+using am.kon.packages.services.kafka.Extensions;
+using Confluent.Kafka;
+
+namespace am.kon.packages.services.kafka.tests;
+
+public sealed class KafkaConsumerConfigExtensionsTests
+{
+    [Fact]
+    public void ToConsumerConfig_WhenAutoOffsetResetIsOmitted_PreservesClientDefault()
+    {
+        var result = CreateConfig().ToConsumerConfig();
+
+        Assert.Null(result.AutoOffsetReset);
+    }
+
+    [Theory]
+    [InlineData(AutoOffsetReset.Earliest)]
+    [InlineData(AutoOffsetReset.Latest)]
+    [InlineData(AutoOffsetReset.Error)]
+    public void ToConsumerConfig_WhenAutoOffsetResetIsConfigured_MapsIt(AutoOffsetReset value)
+    {
+        var config = CreateConfig();
+        config.AutoOffsetReset = value;
+
+        var result = config.ToConsumerConfig();
+
+        Assert.Equal(value, result.AutoOffsetReset);
+    }
+
+    private static KafkaConsumerConfig CreateConfig()
+    {
+        return new KafkaConsumerConfig
+        {
+            BootstrapServers = "broker-1:9092,broker-2:9092,broker-3:9092",
+            MessageMaxBytes = 1_000_000,
+            SocketTimeoutMs = 60_000,
+            GroupId = "orders-history-writer",
+            AutoCommit = false,
+            MakeGroupUnique = false,
+            Topic = "orders.history.v1"
+        };
+    }
+}


### PR DESCRIPTION
## What changed

- adds an optional strongly typed `AutoOffsetReset` setting to `KafkaConsumerConfig`
- maps the setting to Confluent.Kafka without changing behavior when it is omitted
- documents `Error` for archival consumers that must not silently skip expired offsets
- adds focused mapping and backward-compatibility tests

## Why

The staging feed-history writer encountered committed offsets that had already expired. Because the wrapper did not expose this setting, librdkafka used its default `Latest` behavior and reset both partitions to `END`, silently skipping the missing history.

## Impact

This is opt-in and backward compatible. Existing consumers retain their current Confluent.Kafka defaults. A consumer configured with `AutoOffsetReset: Error` reports the offset failure instead of selecting a new position.

## Dependency and rollout

Producer durability PR #7 is merged. This branch now contains a normal, non-rewriting merge of current `main` and targets `main` directly.

After merge, publish a new package and rebuild feed-history-writer against it before adding the staging setting. Do not deploy `AutoOffsetReset: Error` until stale group-offset handling and runtime failure reporting are approved under SL-4664.

## Checks

- `dotnet test --solution am.kon.packages.services.kafka.sln --configuration Release` — 14 passed after merging current `main`
- `git diff --check` passed
- branch is current with `main`

No package was published and no runtime was changed.