### PR TITLE
release: am.kon.packages.services.kafka 0.1.0.10

### DIFF
--- a/.github/workflows/dotnet-beta-release.yml
+++ b/.github/workflows/dotnet-beta-release.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 8
+        dotnet-version: 10.0.x
     - name: Restore dependencies
       run: dotnet restore
     - name: Build

--- a/.github/workflows/dotnet-beta-release.yml
+++ b/.github/workflows/dotnet-beta-release.yml
@@ -25,9 +25,9 @@ jobs:
     - name: Build
       run: dotnet build --no-restore --configuration Release
     - name: Test
-      run: dotnet test --no-build --verbosity normal
+      run: dotnet test --no-build --configuration Release --verbosity normal
     - name: Pack
-      run: dotnet pack --output ./packages --no-build --no-restore
+      run: dotnet pack --output ./packages --no-build --no-restore --configuration Release
     - name: Push
       env:
         api_secret: ${{ secrets.NUGET_PUBLISH_SECRET }}

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 8
+        dotnet-version: 10.0.x
     - name: Restore dependencies
       run: dotnet restore
     - name: Build

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Configure your Kafka services in '**appsettings.json**' as follows:
     "EnsureExistTopics": ["orders.events.v1"],
     "NumPartitionsDefault": 3,
     "ReplicationFactorDefault": 3,
+    "ReconcileExistingTopicConfigs": true,
     "TopicConfigsDefault": {
       "min.insync.replicas": "2",
       "unclean.leader.election.enable": "false"
@@ -104,9 +105,16 @@ These sections define the settings for your Kafka producer and consumer, includi
 
 `EnsureExistTopicSpecifications` is an optional richer contract for topics that need their own partition count, replication factor, or Kafka topic configs. Omitted per-topic partition and replication values fall back to the section defaults. Per-topic `Configs` override matching `TopicConfigsDefault` entries. A detailed specification with the same name as a legacy string entry replaces that legacy definition, which supports an incremental configuration migration without creating the topic twice.
 
-The manager validates topic definitions before contacting Kafka. Partition count and replication factor must be positive, `min.insync.replicas` must be a positive integer no greater than the resolved replication factor, and duplicate or conflicting detailed specifications are rejected.
+The manager validates topic definitions before contacting Kafka. Partition count and replication factor must be positive, `min.insync.replicas` must be a positive integer no greater than the resolved replication factor, `unclean.leader.election.enable` must be a boolean, and duplicate or conflicting detailed specifications are rejected.
 
-The topic manager creates missing topics only. It deliberately does not change partition count, replica assignments, or topic configs on existing topics; those operations require a separately reviewed Kafka migration.
+`ReconcileExistingTopicConfigs` is optional and defaults to `false`, preserving the legacy creation-only behavior. When enabled, the manager describes each existing topic, compares only the supported durability settings, and uses Kafka's incremental alter-config API with `SET` operations only for drifted values. Repeated startup with matching values performs no alteration.
+
+Existing-topic reconciliation currently supports only:
+
+- `min.insync.replicas`
+- `unclean.leader.election.enable`
+
+Other entries, such as `cleanup.policy`, still apply when a topic is created but are not changed on an existing topic. Before reconciling `min.insync.replicas`, the manager validates it against the existing topic's live replication factor. It never increases partitions or changes replica assignments. Enabling reconciliation requires Kafka describe-config and incremental-alter-config permissions. Disabling it later stops future reconciliation but does not roll back dynamic topic values already applied.
 
 ## Implementing Services
 ### KafkaDataProducerService

--- a/README.md
+++ b/README.md
@@ -48,6 +48,26 @@ Configure your Kafka services in '**appsettings.json**' as follows:
     "MakeGroupUnique": false,
     "AutoCommit": true,
     "Topics": ["topic1", "topic2"]
+  },
+  "KafkaTopicManager": {
+    "BootstrapServers": "localhost:9092",
+    "EnsureExistTopics": ["orders.events.v1"],
+    "NumPartitionsDefault": 3,
+    "ReplicationFactorDefault": 3,
+    "TopicConfigsDefault": {
+      "min.insync.replicas": "2",
+      "unclean.leader.election.enable": "false"
+    },
+    "EnsureExistTopicSpecifications": [
+      {
+        "Name": "orders.compacted.v1",
+        "NumPartitions": 6,
+        "ReplicationFactor": 3,
+        "Configs": {
+          "cleanup.policy": "compact"
+        }
+      }
+    ]
   }
 }
 ```
@@ -77,6 +97,16 @@ These sections define the settings for your Kafka producer and consumer, includi
 + **MakeGroupUnique**: When set to true, appends a unique identifier (timestamp) to the GroupId, creating a unique consumer group on every run.
 + **AutoCommit**: If set to true, the consumer's offset will be periodically committed in the background.
 + **Topics**: An array of topics this consumer should subscribe to.
+
+### Kafka topic creation
+
+`KafkaTopicManager` preserves the legacy `EnsureExistTopics` string-array contract. Missing legacy topics use `NumPartitionsDefault`, `ReplicationFactorDefault`, and the optional `TopicConfigsDefault` values.
+
+`EnsureExistTopicSpecifications` is an optional richer contract for topics that need their own partition count, replication factor, or Kafka topic configs. Omitted per-topic partition and replication values fall back to the section defaults. Per-topic `Configs` override matching `TopicConfigsDefault` entries. A detailed specification with the same name as a legacy string entry replaces that legacy definition, which supports an incremental configuration migration without creating the topic twice.
+
+The manager validates topic definitions before contacting Kafka. Partition count and replication factor must be positive, `min.insync.replicas` must be a positive integer no greater than the resolved replication factor, and duplicate or conflicting detailed specifications are rejected.
+
+The topic manager creates missing topics only. It deliberately does not change partition count, replica assignments, or topic configs on existing topics; those operations require a separately reviewed Kafka migration.
 
 ## Implementing Services
 ### KafkaDataProducerService

--- a/README.md
+++ b/README.md
@@ -38,7 +38,10 @@ Configure your Kafka services in '**appsettings.json**' as follows:
     "RequestTimeoutMs": 5000,
     "SocketTimeoutMs": 60000,
     "CompressionType": "gzip",
-    "CompressionLevel": 5
+    "CompressionLevel": 5,
+    "Acks": "all",
+    "EnableIdempotence": true,
+    "MaxInFlight": 5
   },
   "KafkaConsumerConfig": {
     "BootstrapServers": "localhost:9092",
@@ -67,6 +70,11 @@ These sections define the settings for your Kafka producer and consumer, includi
 + **SocketKeepaliveEnable**: Enables TCP keep-alive on the socket connecting to the Kafka broker. It keeps the connection active even if no data is being transferred.
 + **CompressionType**: Specifies the compression codec to use for compressing message sets. Common values are none, gzip, snappy, and lz4.
 + **CompressionLevel**: Represents the compression level for compressed messages. The higher the level, the better the compression.
++ **Acks**: Configures the required Kafka acknowledgements. Use `all` for durable delivery.
++ **EnableIdempotence**: Enables producer idempotence so retries do not create duplicate records within a producer session.
++ **MaxInFlight**: Limits concurrent in-flight requests per broker connection. Keep this at five or lower when idempotence is enabled.
+
+`Acks`, `EnableIdempotence`, and `MaxInFlight` are opt-in for backward compatibility. When they are omitted, the package leaves the underlying Confluent.Kafka defaults unchanged. For durable publication, configure all three values as shown above.
 
 ### KafkaConsumerConfig Properties
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Configure your Kafka services in '**appsettings.json**' as follows:
     "GroupId": "my-consumer-group",
     "MakeGroupUnique": false,
     "AutoCommit": true,
+    "AutoOffsetReset": "Error",
     "Topics": ["topic1", "topic2"]
   }
 }
@@ -84,6 +85,7 @@ These sections define the settings for your Kafka producer and consumer, includi
 + **GroupId**: The name of the consumer group this consumer belongs to. Consumer groups allow a group of consumers to cooperate in consuming the messages.
 + **MakeGroupUnique**: When set to true, appends a unique identifier (timestamp) to the GroupId, creating a unique consumer group on every run.
 + **AutoCommit**: If set to true, the consumer's offset will be periodically committed in the background.
++ **AutoOffsetReset**: Optional Confluent.Kafka policy (`Earliest`, `Latest`, or `Error`) used when no initial offset exists or the committed offset is unavailable. Omit it to preserve the existing client default. Archival consumers should prefer `Error` so retention loss fails visibly instead of silently skipping data.
 + **Topics**: An array of topics this consumer should subscribe to.
 
 ## Implementing Services

--- a/am.kon.packages.services.kafka.sln
+++ b/am.kon.packages.services.kafka.sln
@@ -7,24 +7,53 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{23EFA5E4-F71
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "am.kon.packages.services.kafka", "src\am.kon.packages.services.kafka.csproj", "{F838B919-D6E9-42ED-8DA4-C356792E21B0}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{0AB3BF05-4346-4AA6-1389-037BE0695223}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "am.kon.packages.services.kafka.tests", "tests\am.kon.packages.services.kafka.tests\am.kon.packages.services.kafka.tests.csproj", "{C20BD141-FF44-4C82-810E-F97DF74C1C0C}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{F838B919-D6E9-42ED-8DA4-C356792E21B0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{F838B919-D6E9-42ED-8DA4-C356792E21B0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F838B919-D6E9-42ED-8DA4-C356792E21B0}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{F838B919-D6E9-42ED-8DA4-C356792E21B0}.Debug|x64.Build.0 = Debug|Any CPU
+		{F838B919-D6E9-42ED-8DA4-C356792E21B0}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{F838B919-D6E9-42ED-8DA4-C356792E21B0}.Debug|x86.Build.0 = Debug|Any CPU
 		{F838B919-D6E9-42ED-8DA4-C356792E21B0}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F838B919-D6E9-42ED-8DA4-C356792E21B0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F838B919-D6E9-42ED-8DA4-C356792E21B0}.Release|x64.ActiveCfg = Release|Any CPU
+		{F838B919-D6E9-42ED-8DA4-C356792E21B0}.Release|x64.Build.0 = Release|Any CPU
+		{F838B919-D6E9-42ED-8DA4-C356792E21B0}.Release|x86.ActiveCfg = Release|Any CPU
+		{F838B919-D6E9-42ED-8DA4-C356792E21B0}.Release|x86.Build.0 = Release|Any CPU
+		{C20BD141-FF44-4C82-810E-F97DF74C1C0C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C20BD141-FF44-4C82-810E-F97DF74C1C0C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C20BD141-FF44-4C82-810E-F97DF74C1C0C}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{C20BD141-FF44-4C82-810E-F97DF74C1C0C}.Debug|x64.Build.0 = Debug|Any CPU
+		{C20BD141-FF44-4C82-810E-F97DF74C1C0C}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{C20BD141-FF44-4C82-810E-F97DF74C1C0C}.Debug|x86.Build.0 = Debug|Any CPU
+		{C20BD141-FF44-4C82-810E-F97DF74C1C0C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C20BD141-FF44-4C82-810E-F97DF74C1C0C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C20BD141-FF44-4C82-810E-F97DF74C1C0C}.Release|x64.ActiveCfg = Release|Any CPU
+		{C20BD141-FF44-4C82-810E-F97DF74C1C0C}.Release|x64.Build.0 = Release|Any CPU
+		{C20BD141-FF44-4C82-810E-F97DF74C1C0C}.Release|x86.ActiveCfg = Release|Any CPU
+		{C20BD141-FF44-4C82-810E-F97DF74C1C0C}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
-	GlobalSection(ExtensibilityGlobals) = postSolution
-		SolutionGuid = {942E1E50-5BBA-4D6D-899A-F54F4AC831A9}
-	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{F838B919-D6E9-42ED-8DA4-C356792E21B0} = {23EFA5E4-F71A-42AE-9150-1CBACC4F9519}
+		{C20BD141-FF44-4C82-810E-F97DF74C1C0C} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {942E1E50-5BBA-4D6D-899A-F54F4AC831A9}
 	EndGlobalSection
 EndGlobal

--- a/am.kon.packages.services.kafka.sln
+++ b/am.kon.packages.services.kafka.sln
@@ -7,6 +7,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{23EFA5E4-F71
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "am.kon.packages.services.kafka", "src\am.kon.packages.services.kafka.csproj", "{F838B919-D6E9-42ED-8DA4-C356792E21B0}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{0AB3BF05-4346-4AA6-1389-037BE0695223}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "am.kon.packages.services.kafka.tests", "tests\am.kon.packages.services.kafka.tests\am.kon.packages.services.kafka.tests.csproj", "{BC880928-12DC-448C-B8B8-E21E374A12AD}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -17,14 +21,19 @@ Global
 		{F838B919-D6E9-42ED-8DA4-C356792E21B0}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F838B919-D6E9-42ED-8DA4-C356792E21B0}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F838B919-D6E9-42ED-8DA4-C356792E21B0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BC880928-12DC-448C-B8B8-E21E374A12AD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BC880928-12DC-448C-B8B8-E21E374A12AD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BC880928-12DC-448C-B8B8-E21E374A12AD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BC880928-12DC-448C-B8B8-E21E374A12AD}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
-	GlobalSection(ExtensibilityGlobals) = postSolution
-		SolutionGuid = {942E1E50-5BBA-4D6D-899A-F54F4AC831A9}
-	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{F838B919-D6E9-42ED-8DA4-C356792E21B0} = {23EFA5E4-F71A-42AE-9150-1CBACC4F9519}
+		{BC880928-12DC-448C-B8B8-E21E374A12AD} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {942E1E50-5BBA-4D6D-899A-F54F4AC831A9}
 	EndGlobalSection
 EndGlobal

--- a/global.json
+++ b/global.json
@@ -1,0 +1,5 @@
+{
+  "test": {
+    "runner": "Microsoft.Testing.Platform"
+  }
+}

--- a/src/Config/KafkaConsumerConfig.cs
+++ b/src/Config/KafkaConsumerConfig.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Confluent.Kafka;
 namespace am.kon.packages.services.kafka.Config
 {
     /// <summary>
@@ -40,6 +41,13 @@ namespace am.kon.packages.services.kafka.Config
         /// Autocommit acnowledgement of Kafka message consuming
         /// </summary>
         public bool AutoCommit { get; set; }
+
+        /// <summary>
+        /// Defines how the consumer behaves when there is no initial offset or
+        /// the committed offset is no longer available on the broker.
+        /// When omitted, the underlying Confluent.Kafka default is preserved.
+        /// </summary>
+        public AutoOffsetReset? AutoOffsetReset { get; set; }
 
         /// <summary>
         /// Name of topics to subscribe to

--- a/src/Config/KafkaProducerConfig.cs
+++ b/src/Config/KafkaProducerConfig.cs
@@ -58,9 +58,26 @@ namespace am.kon.packages.services.kafka.Config
         public int CompressionLevel { get; set; }
 
         /// <summary>
+        /// Number of acknowledgements required from Kafka before a produce request succeeds.
+        /// Leave unset to preserve the underlying client default.
+        /// </summary>
+        public string Acks { get; set; }
+
+        /// <summary>
+        /// Enables the idempotent Kafka producer. Leave unset to preserve the underlying client default.
+        /// </summary>
+        public bool? EnableIdempotence { get; set; }
+
+        /// <summary>
+        /// Maximum number of in-flight requests per broker connection.
+        /// When idempotence is enabled, this value must be no greater than five.
+        /// Leave unset to preserve the underlying client default.
+        /// </summary>
+        public int? MaxInFlight { get; set; }
+
+        /// <summary>
         /// Indicates whether to wait for the Topic Manager initialization process before sending messages.
         /// </summary>
         public bool AwaitForTopicManager { get; set; }
     }
 }
-

--- a/src/Config/KafkaTopicCreationConfig.cs
+++ b/src/Config/KafkaTopicCreationConfig.cs
@@ -1,0 +1,19 @@
+using System.Collections.Generic;
+
+namespace am.kon.packages.services.kafka.Config
+{
+    /// <summary>
+    /// Describes how a missing Kafka topic should be created.
+    /// Existing topics are never altered by the topic manager.
+    /// </summary>
+    public class KafkaTopicCreationConfig
+    {
+        public string Name { get; set; }
+
+        public int? NumPartitions { get; set; }
+
+        public short? ReplicationFactor { get; set; }
+
+        public Dictionary<string, string> Configs { get; set; }
+    }
+}

--- a/src/Config/KafkaTopicCreationConfig.cs
+++ b/src/Config/KafkaTopicCreationConfig.cs
@@ -3,8 +3,8 @@ using System.Collections.Generic;
 namespace am.kon.packages.services.kafka.Config
 {
     /// <summary>
-    /// Describes how a missing Kafka topic should be created.
-    /// Existing topics are never altered by the topic manager.
+    /// Describes how a missing Kafka topic should be created and which supported
+    /// configuration values may be reconciled when existing-topic reconciliation is enabled.
     /// </summary>
     public class KafkaTopicCreationConfig
     {

--- a/src/Config/KafkaTopicManagerConfig.cs
+++ b/src/Config/KafkaTopicManagerConfig.cs
@@ -15,6 +15,12 @@ namespace am.kon.packages.services.kafka.Config
         public short ReplicationFactorDefault { get; set; }
 
         /// <summary>
+        /// Opts into idempotent reconciliation of supported configuration values on existing topics.
+        /// When omitted or false, the manager preserves its legacy creation-only behavior.
+        /// </summary>
+        public bool ReconcileExistingTopicConfigs { get; set; }
+
+        /// <summary>
         /// Optional topic-level configuration applied to every topic created by this manager.
         /// Per-topic values in <see cref="EnsureExistTopicSpecifications"/> take precedence.
         /// </summary>

--- a/src/Config/KafkaTopicManagerConfig.cs
+++ b/src/Config/KafkaTopicManagerConfig.cs
@@ -1,15 +1,29 @@
+using System.Collections.Generic;
+
 namespace am.kon.packages.services.kafka.Config
 {
     public class KafkaTopicManagerConfig
     {
         public const string SectionDefaultName = "KafkaTopicManager";
-        
+
         public string BootstrapServers { get; set; }
 
         public string[] EnsureExistTopics { get; set; }
-        
+
         public int NumPartitionsDefault { get; set; }
-        
+
         public short ReplicationFactorDefault { get; set; }
+
+        /// <summary>
+        /// Optional topic-level configuration applied to every topic created by this manager.
+        /// Per-topic values in <see cref="EnsureExistTopicSpecifications"/> take precedence.
+        /// </summary>
+        public Dictionary<string, string> TopicConfigsDefault { get; set; }
+
+        /// <summary>
+        /// Optional detailed topic definitions. These may be used alongside
+        /// <see cref="EnsureExistTopics"/> while services migrate from the legacy string list.
+        /// </summary>
+        public KafkaTopicCreationConfig[] EnsureExistTopicSpecifications { get; set; }
     }
 }

--- a/src/Extensions/KafkaConsumerConfigExtensions.cs
+++ b/src/Extensions/KafkaConsumerConfigExtensions.cs
@@ -22,11 +22,11 @@ namespace am.kon.packages.services.kafka.Extensions
                 MessageMaxBytes = kafkaConsumerConfig.MessageMaxBytes,
                 SocketTimeoutMs = kafkaConsumerConfig.SocketTimeoutMs,
                 GroupId = kafkaConsumerConfig.GroupId,
-                EnableAutoCommit = kafkaConsumerConfig.AutoCommit
+                EnableAutoCommit = kafkaConsumerConfig.AutoCommit,
+                AutoOffsetReset = kafkaConsumerConfig.AutoOffsetReset
             };
 
             return res;
         }
     }
 }
-

--- a/src/Extensions/KafkaProducerConfigExtensions.cs
+++ b/src/Extensions/KafkaProducerConfigExtensions.cs
@@ -16,7 +16,10 @@ namespace am.kon.packages.services.kafka.Extensions
         /// <returns>Instance of the <see cref="ProducerConfig"/> class.</returns>
         public static ProducerConfig ToProducerConfig(this KafkaProducerConfig kafkaProducerConfig)
         {
-            return new ProducerConfig()
+            if (kafkaProducerConfig == null)
+                throw new ArgumentNullException(nameof(kafkaProducerConfig));
+
+            var producerConfig = new ProducerConfig()
             {
                 BootstrapServers = kafkaProducerConfig.BootstrapServers,
                 MessageMaxBytes = kafkaProducerConfig.MessageMaxBytes,
@@ -26,9 +29,30 @@ namespace am.kon.packages.services.kafka.Extensions
                 SocketTimeoutMs = kafkaProducerConfig.SocketTimeoutMs,
                 SocketKeepaliveEnable = kafkaProducerConfig.SocketKeepaliveEnable,
                 CompressionType = (CompressionType)Enum.Parse(typeof(CompressionType), kafkaProducerConfig.CompressionType, true),
-                CompressionLevel = kafkaProducerConfig.CompressionLevel//,
+                CompressionLevel = kafkaProducerConfig.CompressionLevel
             };
+
+            if (!string.IsNullOrWhiteSpace(kafkaProducerConfig.Acks))
+                producerConfig.Acks = ParseAcks(kafkaProducerConfig.Acks);
+
+            if (kafkaProducerConfig.EnableIdempotence.HasValue)
+                producerConfig.EnableIdempotence = kafkaProducerConfig.EnableIdempotence.Value;
+
+            if (kafkaProducerConfig.MaxInFlight.HasValue)
+                producerConfig.MaxInFlight = kafkaProducerConfig.MaxInFlight.Value;
+
+            return producerConfig;
+        }
+
+        private static Acks ParseAcks(string value)
+        {
+            if (Enum.TryParse(value, true, out Acks parsed)
+                && (parsed == Acks.None || parsed == Acks.Leader || parsed == Acks.All))
+                return parsed;
+
+            throw new ArgumentException(
+                $"Unsupported Kafka producer acknowledgement value '{value}'. Use 'none', 'leader', 'all', '0', '1', or '-1'.",
+                nameof(value));
         }
     }
 }
-

--- a/src/KafkaConsumeExceptionClassifier.cs
+++ b/src/KafkaConsumeExceptionClassifier.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using Confluent.Kafka;
+
+namespace am.kon.packages.services.kafka
+{
+    internal static class KafkaConsumeExceptionClassifier
+    {
+        internal static bool IsAutoOffsetResetError(Exception exception)
+        {
+            return exception is ConsumeException consumeException
+                && consumeException.Error.Code == ErrorCode.Local_AutoOffsetReset;
+        }
+    }
+}

--- a/src/KafkaDataConsumerService.cs
+++ b/src/KafkaDataConsumerService.cs
@@ -35,9 +35,25 @@ namespace am.kon.packages.services.kafka
 
         private readonly KafkaTopicManagerService _kafkaTopicManagerService;
 
+        private Action _autoOffsetResetErrorHandler;
+
         protected int _disposed;
 
         protected Func<Message<TKey, TValue>, Task<bool>> ProcessMessageAsync { get; set; }
+
+        /// <summary>
+        /// Sets the callback invoked when Confluent.Kafka reports that the configured
+        /// offset reset policy cannot resolve an unavailable committed offset.
+        /// A subsequent call replaces the previous callback; passing <c>null</c> disables it.
+        /// </summary>
+        /// <param name="handler">
+        /// Synchronous, non-blocking callback invoked once for each
+        /// <see cref="ErrorCode.Local_AutoOffsetReset"/> consume error.
+        /// </param>
+        protected void SetAutoOffsetResetErrorHandler(Action handler)
+        {
+            _autoOffsetResetErrorHandler = handler;
+        }
 
         public KafkaDataConsumerService(
             ILogger<KafkaDataConsumerService<TKey, TValue>> logger,
@@ -135,7 +151,7 @@ namespace am.kon.packages.services.kafka
                         // if AutoCommit is enabled there is no need to coll _consumer.Commit
                         bool commitConsume = !_kafkaConsumerConfig.AutoCommit;
 
-                        if(ProcessMessageAsync == null)
+                        if (ProcessMessageAsync == null)
                         {
                             _messagesQueue.Enqueue(consumeResult.Message);
                             Interlocked.Increment(ref _messagesQueueLength);
@@ -158,6 +174,7 @@ namespace am.kon.packages.services.kafka
                     }
                     catch (Exception ex)
                     {
+                        NotifyAutoOffsetResetError(ex);
                         _logger.LogError(ex, $"Consume error. ClientID: {_consumer.Name}");
                     }
                 }
@@ -169,6 +186,27 @@ namespace am.kon.packages.services.kafka
             finally
             {
                 Interlocked.Exchange(ref _consumingIsInProgress, 0);
+            }
+        }
+
+        private void NotifyAutoOffsetResetError(Exception exception)
+        {
+            if (!KafkaConsumeExceptionClassifier.IsAutoOffsetResetError(exception))
+                return;
+
+            Action handler = _autoOffsetResetErrorHandler;
+            if (handler == null)
+                return;
+
+            try
+            {
+                handler();
+            }
+            catch (Exception callbackException)
+            {
+                _logger.LogWarning(
+                    callbackException,
+                    "Kafka auto-offset-reset error telemetry callback failed.");
             }
         }
 
@@ -199,12 +237,12 @@ namespace am.kon.packages.services.kafka
         /// </summary>
         protected virtual void Dispose(bool disposing)
         {
-            if(!disposing)
+            if (!disposing)
                 return;
 
             int originalValue = Interlocked.CompareExchange(ref _disposed, 1, 0);
 
-            if(originalValue != 0)
+            if (originalValue != 0)
                 return;
 
             _consumer?.Dispose();
@@ -222,4 +260,3 @@ namespace am.kon.packages.services.kafka
         }
     }
 }
-

--- a/src/KafkaTopicConfigReconciliationPlanner.cs
+++ b/src/KafkaTopicConfigReconciliationPlanner.cs
@@ -1,0 +1,111 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using Confluent.Kafka.Admin;
+
+namespace am.kon.packages.services.kafka
+{
+    internal static class KafkaTopicConfigReconciliationPlanner
+    {
+        internal const string MinInSyncReplicasConfigName = "min.insync.replicas";
+        internal const string UncleanLeaderElectionConfigName = "unclean.leader.election.enable";
+
+        private static readonly HashSet<string> SupportedConfigNames =
+            new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+            {
+                MinInSyncReplicasConfigName,
+                UncleanLeaderElectionConfigName,
+            };
+
+        public static Dictionary<string, string> ResolveDesiredConfigs(
+            IReadOnlyDictionary<string, string> configuredValues)
+        {
+            var desired = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            if (configuredValues == null)
+                return desired;
+
+            foreach (var entry in configuredValues)
+            {
+                if (SupportedConfigNames.Contains(entry.Key))
+                    desired[CanonicalName(entry.Key)] = entry.Value;
+            }
+
+            return desired;
+        }
+
+        public static List<ConfigEntry> ResolveAlterations(
+            IReadOnlyDictionary<string, string> desiredValues,
+            IReadOnlyDictionary<string, string> currentValues)
+        {
+            var current = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            if (currentValues != null)
+            {
+                foreach (var entry in currentValues)
+                    current[entry.Key] = entry.Value;
+            }
+
+            return desiredValues
+                .OrderBy(entry => entry.Key, StringComparer.Ordinal)
+                .Where(entry =>
+                    !current.TryGetValue(entry.Key, out var currentValue) ||
+                    !ValuesEqual(entry.Key, entry.Value, currentValue))
+                .Select(entry => new ConfigEntry
+                {
+                    Name = entry.Key,
+                    Value = entry.Value,
+                    IncrementalOperation = AlterConfigOpType.Set,
+                })
+                .ToList();
+        }
+
+        public static void ValidateExistingReplicationFactor(
+            string topicName,
+            IReadOnlyDictionary<string, string> desiredValues,
+            int existingReplicationFactor)
+        {
+            if (!desiredValues.TryGetValue(MinInSyncReplicasConfigName, out var value))
+                return;
+
+            if (!int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var minInSyncReplicas))
+                throw new ArgumentException($"Kafka topic '{topicName}' has invalid {MinInSyncReplicasConfigName} value '{value}'.");
+
+            if (existingReplicationFactor <= 0)
+                throw new InvalidOperationException($"Kafka topic '{topicName}' has no readable partition replica metadata.");
+
+            if (minInSyncReplicas > existingReplicationFactor)
+            {
+                throw new InvalidOperationException(
+                    $"Kafka topic '{topicName}' cannot reconcile {MinInSyncReplicasConfigName}={minInSyncReplicas} " +
+                    $"because its existing replication factor is {existingReplicationFactor}. " +
+                    "The topic manager does not change replica assignments.");
+            }
+        }
+
+        private static bool ValuesEqual(string name, string desiredValue, string currentValue)
+        {
+            if (string.Equals(name, MinInSyncReplicasConfigName, StringComparison.OrdinalIgnoreCase) &&
+                int.TryParse(desiredValue, NumberStyles.Integer, CultureInfo.InvariantCulture, out var desiredInteger) &&
+                int.TryParse(currentValue, NumberStyles.Integer, CultureInfo.InvariantCulture, out var currentInteger))
+            {
+                return desiredInteger == currentInteger;
+            }
+
+            if (string.Equals(name, UncleanLeaderElectionConfigName, StringComparison.OrdinalIgnoreCase) &&
+                bool.TryParse(desiredValue, out var desiredBoolean) &&
+                bool.TryParse(currentValue, out var currentBoolean))
+            {
+                return desiredBoolean == currentBoolean;
+            }
+
+            return string.Equals(desiredValue, currentValue, StringComparison.Ordinal);
+        }
+
+        private static string CanonicalName(string name)
+        {
+            return string.Equals(name, MinInSyncReplicasConfigName, StringComparison.OrdinalIgnoreCase)
+                ? MinInSyncReplicasConfigName
+                : UncleanLeaderElectionConfigName;
+        }
+    }
+}

--- a/src/KafkaTopicManagerService.cs
+++ b/src/KafkaTopicManagerService.cs
@@ -101,7 +101,8 @@ namespace am.kon.packages.services.kafka
         /// <returns>A task representing the asynchronous operation of creating the required Kafka topics.</returns>
         public async Task CreateTopics()
         {
-            var ensureTopics = ResolveEnsureTopics();
+            var topicSpecifications = KafkaTopicSpecificationResolver.Resolve(_config);
+            var ensureTopics = topicSpecifications.Select(topic => topic.Name).ToArray();
             LogConfiguration(ensureTopics);
 
             if (ensureTopics.Length == 0)
@@ -115,8 +116,9 @@ namespace am.kon.packages.services.kafka
             {
                 bool topicsCreationError = false;
 
-                foreach (var topicName in ensureTopics)
+                foreach (var topicSpecification in topicSpecifications)
                 {
+                    var topicName = topicSpecification.Name;
                     try
                     {
                         var topicExists = TopicExists(topicName);
@@ -128,15 +130,7 @@ namespace am.kon.packages.services.kafka
                         }
 
                         // crete topic
-                        await _adminClient.CreateTopicsAsync(new[]
-                        {
-                            new TopicSpecification
-                            {
-                                Name = topicName,
-                                NumPartitions = _config.NumPartitionsDefault,
-                                ReplicationFactor = _config.ReplicationFactorDefault,
-                            }
-                        });
+                        await _adminClient.CreateTopicsAsync(new[] { topicSpecification });
                         _logger.LogInformation("Kafka topic created: {TopicName}", topicName);
                     }
                     catch (CreateTopicsException ex)
@@ -183,18 +177,6 @@ namespace am.kon.packages.services.kafka
                     _topicsCreated = true;
                 }
             }
-        }
-
-        private string[] ResolveEnsureTopics()
-        {
-            if (_config.EnsureExistTopics == null || _config.EnsureExistTopics.Length == 0)
-                return Array.Empty<string>();
-
-            return _config.EnsureExistTopics
-                .Where(topic => !string.IsNullOrWhiteSpace(topic))
-                .Select(topic => topic.Trim())
-                .Distinct(StringComparer.OrdinalIgnoreCase)
-                .ToArray();
         }
 
         private void LogConfiguration(string[] ensureTopics)
@@ -244,12 +226,12 @@ namespace am.kon.packages.services.kafka
         /// </summary>
         protected virtual void Dispose(bool disposing)
         {
-            if(!disposing)
+            if (!disposing)
                 return;
 
             int originalValue = Interlocked.CompareExchange(ref _disposed, 1, 0);
 
-            if(originalValue != 0)
+            if (originalValue != 0)
                 return;
 
             _adminClient?.Dispose();

--- a/src/KafkaTopicManagerService.cs
+++ b/src/KafkaTopicManagerService.cs
@@ -126,6 +126,9 @@ namespace am.kon.packages.services.kafka
                         // if topic exist continue to next topic
                         if (topicExists)
                         {
+                            if (_config.ReconcileExistingTopicConfigs)
+                                await ReconcileExistingTopicConfigs(topicSpecification);
+
                             continue;
                         }
 
@@ -137,6 +140,23 @@ namespace am.kon.packages.services.kafka
                     {
                         if (ex.Results.Any(r => r.Error.Code == ErrorCode.TopicAlreadyExists))
                         {
+                            if (_config.ReconcileExistingTopicConfigs)
+                            {
+                                try
+                                {
+                                    await ReconcileExistingTopicConfigs(topicSpecification);
+                                }
+                                catch (Exception reconciliationException)
+                                {
+                                    _logger.LogError(
+                                        reconciliationException,
+                                        "Failed to reconcile existing Kafka topic configs for {TopicName}.",
+                                        topicName);
+                                    topicsCreationError = true;
+                                    break;
+                                }
+                            }
+
                             continue;
                         }
                         else
@@ -219,6 +239,62 @@ namespace am.kon.packages.services.kafka
                 _logger.LogError(ex, "Failed to read Kafka metadata for topic {TopicName}.", topicName);
                 return false;
             }
+        }
+
+        private async Task ReconcileExistingTopicConfigs(TopicSpecification topicSpecification)
+        {
+            var desiredConfigs = KafkaTopicConfigReconciliationPlanner.ResolveDesiredConfigs(topicSpecification.Configs);
+            if (desiredConfigs.Count == 0)
+                return;
+
+            var metadata = _adminClient.GetMetadata(topicSpecification.Name, TimeSpan.FromSeconds(5));
+            var topicMetadata = metadata.Topics.FirstOrDefault(topic =>
+                string.Equals(topic.Topic, topicSpecification.Name, StringComparison.OrdinalIgnoreCase) &&
+                topic.Error.Code == ErrorCode.NoError);
+            if (topicMetadata == null || topicMetadata.Partitions == null || topicMetadata.Partitions.Count == 0)
+            {
+                throw new InvalidOperationException(
+                    $"Kafka topic '{topicSpecification.Name}' has no readable partition metadata for config reconciliation.");
+            }
+
+            var existingReplicationFactor = topicMetadata.Partitions.Min(partition => partition.Replicas.Count());
+            KafkaTopicConfigReconciliationPlanner.ValidateExistingReplicationFactor(
+                topicSpecification.Name,
+                desiredConfigs,
+                existingReplicationFactor);
+
+            var resource = new ConfigResource
+            {
+                Type = ResourceType.Topic,
+                Name = topicSpecification.Name,
+            };
+            var describeResults = await _adminClient.DescribeConfigsAsync(new[] { resource });
+            var describeResult = describeResults.SingleOrDefault(result =>
+                string.Equals(result.ConfigResource.Name, topicSpecification.Name, StringComparison.OrdinalIgnoreCase));
+            if (describeResult == null)
+                throw new InvalidOperationException($"Kafka returned no config metadata for topic '{topicSpecification.Name}'.");
+
+            var currentConfigs = describeResult.Entries.ToDictionary(
+                entry => entry.Key,
+                entry => entry.Value.Value,
+                StringComparer.OrdinalIgnoreCase);
+            var alterations = KafkaTopicConfigReconciliationPlanner.ResolveAlterations(desiredConfigs, currentConfigs);
+            if (alterations.Count == 0)
+            {
+                _logger.LogDebug("Kafka topic configs already match for {TopicName}.", topicSpecification.Name);
+                return;
+            }
+
+            await _adminClient.IncrementalAlterConfigsAsync(
+                new Dictionary<ConfigResource, List<ConfigEntry>>
+                {
+                    [resource] = alterations,
+                });
+
+            _logger.LogInformation(
+                "Kafka topic configs reconciled: TopicName={TopicName}, Configs={Configs}.",
+                topicSpecification.Name,
+                string.Join(", ", alterations.Select(entry => $"{entry.Name}={entry.Value}")));
         }
 
         /// <summary>

--- a/src/KafkaTopicSpecificationResolver.cs
+++ b/src/KafkaTopicSpecificationResolver.cs
@@ -10,6 +10,7 @@ namespace am.kon.packages.services.kafka
     internal static class KafkaTopicSpecificationResolver
     {
         private const string MinInSyncReplicasConfigName = "min.insync.replicas";
+        private const string UncleanLeaderElectionConfigName = "unclean.leader.election.enable";
 
         public static TopicSpecification[] Resolve(KafkaTopicManagerConfig config)
         {
@@ -104,7 +105,7 @@ namespace am.kon.packages.services.kafka
             foreach (var entry in NormalizeConfigs(topicConfigs, $"topic '{topicName}' configs"))
                 configs[entry.Key] = entry.Value;
 
-            ValidateMinInSyncReplicas(topicName, replicationFactor, configs);
+            ValidateAndNormalizeDurabilityConfigs(topicName, replicationFactor, configs);
 
             return new TopicSpecification
             {
@@ -142,27 +143,60 @@ namespace am.kon.packages.services.kafka
             return normalized;
         }
 
-        private static void ValidateMinInSyncReplicas(
+        private static void ValidateAndNormalizeDurabilityConfigs(
             string topicName,
             short replicationFactor,
-            IReadOnlyDictionary<string, string> configs)
+            IDictionary<string, string> configs)
         {
-            if (!configs.TryGetValue(MinInSyncReplicasConfigName, out var configuredValue))
-                return;
-
-            if (!int.TryParse(configuredValue, NumberStyles.Integer, CultureInfo.InvariantCulture, out var minInSyncReplicas) ||
-                minInSyncReplicas <= 0)
+            if (configs.TryGetValue(MinInSyncReplicasConfigName, out var configuredValue))
             {
-                throw new ArgumentException(
-                    $"Kafka topic '{topicName}' has invalid {MinInSyncReplicasConfigName} value '{configuredValue}'.");
+                if (!int.TryParse(configuredValue, NumberStyles.Integer, CultureInfo.InvariantCulture, out var minInSyncReplicas) ||
+                    minInSyncReplicas <= 0)
+                {
+                    throw new ArgumentException(
+                        $"Kafka topic '{topicName}' has invalid {MinInSyncReplicasConfigName} value '{configuredValue}'.");
+                }
+
+                if (minInSyncReplicas > replicationFactor)
+                {
+                    throw new ArgumentException(
+                        $"Kafka topic '{topicName}' has {MinInSyncReplicasConfigName}={minInSyncReplicas}, " +
+                        $"which exceeds replication factor {replicationFactor}.");
+                }
+
+                SetCanonicalConfigValue(
+                    configs,
+                    MinInSyncReplicasConfigName,
+                    minInSyncReplicas.ToString(CultureInfo.InvariantCulture));
             }
 
-            if (minInSyncReplicas > replicationFactor)
+            if (configs.TryGetValue(UncleanLeaderElectionConfigName, out var uncleanLeaderElectionValue))
             {
-                throw new ArgumentException(
-                    $"Kafka topic '{topicName}' has {MinInSyncReplicasConfigName}={minInSyncReplicas}, " +
-                    $"which exceeds replication factor {replicationFactor}.");
+                if (!bool.TryParse(uncleanLeaderElectionValue, out var uncleanLeaderElectionEnabled))
+                {
+                    throw new ArgumentException(
+                        $"Kafka topic '{topicName}' has invalid {UncleanLeaderElectionConfigName} value " +
+                        $"'{uncleanLeaderElectionValue}'.");
+                }
+
+                SetCanonicalConfigValue(
+                    configs,
+                    UncleanLeaderElectionConfigName,
+                    uncleanLeaderElectionEnabled ? "true" : "false");
             }
+        }
+
+        private static void SetCanonicalConfigValue(
+            IDictionary<string, string> configs,
+            string canonicalName,
+            string value)
+        {
+            var existingName = configs.Keys.First(key =>
+                string.Equals(key, canonicalName, StringComparison.OrdinalIgnoreCase));
+            if (!string.Equals(existingName, canonicalName, StringComparison.Ordinal))
+                configs.Remove(existingName);
+
+            configs[canonicalName] = value;
         }
 
         private static string RequireTopicName(string topicName)

--- a/src/KafkaTopicSpecificationResolver.cs
+++ b/src/KafkaTopicSpecificationResolver.cs
@@ -1,0 +1,198 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using am.kon.packages.services.kafka.Config;
+using Confluent.Kafka.Admin;
+
+namespace am.kon.packages.services.kafka
+{
+    internal static class KafkaTopicSpecificationResolver
+    {
+        private const string MinInSyncReplicasConfigName = "min.insync.replicas";
+
+        public static TopicSpecification[] Resolve(KafkaTopicManagerConfig config)
+        {
+            if (config == null)
+                throw new ArgumentNullException(nameof(config));
+
+            var resolved = new Dictionary<string, TopicSpecification>(StringComparer.OrdinalIgnoreCase);
+            var defaultConfigs = NormalizeConfigs(config.TopicConfigsDefault, nameof(config.TopicConfigsDefault));
+
+            foreach (var topicName in ResolveLegacyTopicNames(config.EnsureExistTopics))
+            {
+                resolved.Add(
+                    topicName,
+                    CreateSpecification(
+                        topicName,
+                        config.NumPartitionsDefault,
+                        config.ReplicationFactorDefault,
+                        defaultConfigs,
+                        null));
+            }
+
+            var detailedSpecifications = new Dictionary<string, TopicSpecification>(StringComparer.OrdinalIgnoreCase);
+            foreach (var topicConfig in config.EnsureExistTopicSpecifications ?? Array.Empty<KafkaTopicCreationConfig>())
+            {
+                if (topicConfig == null)
+                    throw new ArgumentException("Detailed Kafka topic specifications cannot contain null entries.", nameof(config));
+
+                var topicName = RequireTopicName(topicConfig.Name);
+                var specification = CreateSpecification(
+                    topicName,
+                    topicConfig.NumPartitions ?? config.NumPartitionsDefault,
+                    topicConfig.ReplicationFactor ?? config.ReplicationFactorDefault,
+                    defaultConfigs,
+                    topicConfig.Configs);
+
+                if (detailedSpecifications.TryGetValue(topicName, out var existing))
+                {
+                    var errorKind = AreEquivalent(existing, specification) ? "Duplicate" : "Conflicting";
+                    throw new ArgumentException(
+                        $"{errorKind} detailed Kafka topic specification for '{topicName}'.",
+                        nameof(config));
+                }
+
+                detailedSpecifications.Add(topicName, specification);
+
+                // A detailed definition intentionally replaces the legacy definition with
+                // the same name, providing a backward-compatible migration path.
+                resolved[topicName] = specification;
+            }
+
+            return resolved.Values.ToArray();
+        }
+
+        private static IEnumerable<string> ResolveLegacyTopicNames(IEnumerable<string> topicNames)
+        {
+            if (topicNames == null)
+                return Array.Empty<string>();
+
+            return topicNames
+                .Where(topic => !string.IsNullOrWhiteSpace(topic))
+                .Select(topic => topic.Trim())
+                .Distinct(StringComparer.OrdinalIgnoreCase);
+        }
+
+        private static TopicSpecification CreateSpecification(
+            string topicName,
+            int numPartitions,
+            short replicationFactor,
+            IReadOnlyDictionary<string, string> defaultConfigs,
+            IDictionary<string, string> topicConfigs)
+        {
+            if (numPartitions <= 0)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(numPartitions),
+                    numPartitions,
+                    $"Kafka topic '{topicName}' must have a positive partition count.");
+            }
+
+            if (replicationFactor <= 0)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(replicationFactor),
+                    replicationFactor,
+                    $"Kafka topic '{topicName}' must have a positive replication factor.");
+            }
+
+            var configs = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var entry in defaultConfigs)
+                configs.Add(entry.Key, entry.Value);
+
+            foreach (var entry in NormalizeConfigs(topicConfigs, $"topic '{topicName}' configs"))
+                configs[entry.Key] = entry.Value;
+
+            ValidateMinInSyncReplicas(topicName, replicationFactor, configs);
+
+            return new TopicSpecification
+            {
+                Name = topicName,
+                NumPartitions = numPartitions,
+                ReplicationFactor = replicationFactor,
+                Configs = configs.Count == 0 ? null : configs,
+            };
+        }
+
+        private static Dictionary<string, string> NormalizeConfigs(
+            IEnumerable<KeyValuePair<string, string>> configs,
+            string configSource)
+        {
+            var normalized = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            if (configs == null)
+                return normalized;
+
+            foreach (var entry in configs)
+            {
+                if (string.IsNullOrWhiteSpace(entry.Key))
+                    throw new ArgumentException($"{configSource} contains an empty Kafka config key.");
+
+                if (entry.Value == null)
+                    throw new ArgumentException($"Kafka config '{entry.Key}' in {configSource} has a null value.");
+
+                var key = entry.Key.Trim();
+                var value = entry.Value.Trim();
+                if (normalized.TryGetValue(key, out var existing) && !string.Equals(existing, value, StringComparison.Ordinal))
+                    throw new ArgumentException($"{configSource} contains conflicting values for Kafka config '{key}'.");
+
+                normalized[key] = value;
+            }
+
+            return normalized;
+        }
+
+        private static void ValidateMinInSyncReplicas(
+            string topicName,
+            short replicationFactor,
+            IReadOnlyDictionary<string, string> configs)
+        {
+            if (!configs.TryGetValue(MinInSyncReplicasConfigName, out var configuredValue))
+                return;
+
+            if (!int.TryParse(configuredValue, NumberStyles.Integer, CultureInfo.InvariantCulture, out var minInSyncReplicas) ||
+                minInSyncReplicas <= 0)
+            {
+                throw new ArgumentException(
+                    $"Kafka topic '{topicName}' has invalid {MinInSyncReplicasConfigName} value '{configuredValue}'.");
+            }
+
+            if (minInSyncReplicas > replicationFactor)
+            {
+                throw new ArgumentException(
+                    $"Kafka topic '{topicName}' has {MinInSyncReplicasConfigName}={minInSyncReplicas}, " +
+                    $"which exceeds replication factor {replicationFactor}.");
+            }
+        }
+
+        private static string RequireTopicName(string topicName)
+        {
+            if (string.IsNullOrWhiteSpace(topicName))
+                throw new ArgumentException("Detailed Kafka topic specifications require a non-empty topic name.");
+
+            return topicName.Trim();
+        }
+
+        private static bool AreEquivalent(TopicSpecification left, TopicSpecification right)
+        {
+            return left.NumPartitions == right.NumPartitions &&
+                   left.ReplicationFactor == right.ReplicationFactor &&
+                   ConfigsEqual(left.Configs, right.Configs);
+        }
+
+        private static bool ConfigsEqual(
+            IReadOnlyDictionary<string, string> left,
+            IReadOnlyDictionary<string, string> right)
+        {
+            if (left == null || left.Count == 0)
+                return right == null || right.Count == 0;
+
+            if (right == null || left.Count != right.Count)
+                return false;
+
+            return left.All(entry =>
+                right.TryGetValue(entry.Key, out var value) &&
+                string.Equals(entry.Value, value, StringComparison.Ordinal));
+        }
+    }
+}

--- a/src/Properties/AssemblyInfo.cs
+++ b/src/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("am.kon.packages.services.kafka.tests")]

--- a/src/am.kon.packages.services.kafka.csproj
+++ b/src/am.kon.packages.services.kafka.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>disable</Nullable>
     <PackageId>am.kon.packages.services.kafka</PackageId>
-    <PackageVersion>0.1.0.9</PackageVersion>
+    <PackageVersion>0.1.0.10</PackageVersion>
     <Authors>sergey konakov</Authors>
     <Description>Kafka connectioon component to be used as a service with dependency injection in .net core applications implementing functionality to interact with Kafka server. Wrapping Confluent.Kafka package.</Description>
     <RepositoryUrl>https://github.com/konak/am.kon.packages.services.kafka</RepositoryUrl>

--- a/tests/am.kon.packages.services.kafka.tests/KafkaConsumeExceptionClassifierTests.cs
+++ b/tests/am.kon.packages.services.kafka.tests/KafkaConsumeExceptionClassifierTests.cs
@@ -1,0 +1,41 @@
+using Confluent.Kafka;
+
+namespace am.kon.packages.services.kafka.tests;
+
+public sealed class KafkaConsumeExceptionClassifierTests
+{
+    [Fact]
+    public void IsAutoOffsetResetError_WhenConsumeErrorIsLocalAutoOffsetReset_ReturnsTrue()
+    {
+        var exception = CreateConsumeException(ErrorCode.Local_AutoOffsetReset);
+
+        var result = KafkaConsumeExceptionClassifier.IsAutoOffsetResetError(exception);
+
+        Assert.True(result);
+    }
+
+    [Theory]
+    [InlineData(ErrorCode.Local_Application)]
+    [InlineData(ErrorCode.OffsetOutOfRange)]
+    public void IsAutoOffsetResetError_WhenConsumeErrorHasDifferentCode_ReturnsFalse(ErrorCode errorCode)
+    {
+        var exception = CreateConsumeException(errorCode);
+
+        var result = KafkaConsumeExceptionClassifier.IsAutoOffsetResetError(exception);
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void IsAutoOffsetResetError_WhenExceptionIsNotConsumeException_ReturnsFalse()
+    {
+        var result = KafkaConsumeExceptionClassifier.IsAutoOffsetResetError(new InvalidOperationException());
+
+        Assert.False(result);
+    }
+
+    private static ConsumeException CreateConsumeException(ErrorCode errorCode)
+    {
+        return new ConsumeException(null, new Error(errorCode));
+    }
+}

--- a/tests/am.kon.packages.services.kafka.tests/KafkaConsumerConfigExtensionsTests.cs
+++ b/tests/am.kon.packages.services.kafka.tests/KafkaConsumerConfigExtensionsTests.cs
@@ -1,0 +1,44 @@
+using am.kon.packages.services.kafka.Config;
+using am.kon.packages.services.kafka.Extensions;
+using Confluent.Kafka;
+
+namespace am.kon.packages.services.kafka.tests;
+
+public sealed class KafkaConsumerConfigExtensionsTests
+{
+    [Fact]
+    public void ToConsumerConfig_WhenAutoOffsetResetIsOmitted_PreservesClientDefault()
+    {
+        var result = CreateConfig().ToConsumerConfig();
+
+        Assert.Null(result.AutoOffsetReset);
+    }
+
+    [Theory]
+    [InlineData(AutoOffsetReset.Earliest)]
+    [InlineData(AutoOffsetReset.Latest)]
+    [InlineData(AutoOffsetReset.Error)]
+    public void ToConsumerConfig_WhenAutoOffsetResetIsConfigured_MapsIt(AutoOffsetReset value)
+    {
+        var config = CreateConfig();
+        config.AutoOffsetReset = value;
+
+        var result = config.ToConsumerConfig();
+
+        Assert.Equal(value, result.AutoOffsetReset);
+    }
+
+    private static KafkaConsumerConfig CreateConfig()
+    {
+        return new KafkaConsumerConfig
+        {
+            BootstrapServers = "broker-1:9092,broker-2:9092,broker-3:9092",
+            MessageMaxBytes = 1_000_000,
+            SocketTimeoutMs = 60_000,
+            GroupId = "orders-history-writer",
+            AutoCommit = false,
+            MakeGroupUnique = false,
+            Topic = "orders.history.v1"
+        };
+    }
+}

--- a/tests/am.kon.packages.services.kafka.tests/KafkaProducerConfigExtensionsTests.cs
+++ b/tests/am.kon.packages.services.kafka.tests/KafkaProducerConfigExtensionsTests.cs
@@ -1,0 +1,79 @@
+using am.kon.packages.services.kafka.Config;
+using am.kon.packages.services.kafka.Extensions;
+using Confluent.Kafka;
+
+namespace am.kon.packages.services.kafka.tests;
+
+public sealed class KafkaProducerConfigExtensionsTests
+{
+    [Fact]
+    public void ToProducerConfig_WhenDurabilityOptionsAreOmitted_PreservesClientDefaults()
+    {
+        var result = CreateConfig().ToProducerConfig();
+
+        Assert.Null(result.Acks);
+        Assert.Null(result.EnableIdempotence);
+        Assert.Null(result.MaxInFlight);
+    }
+
+    [Fact]
+    public void ToProducerConfig_WhenDurabilityOptionsAreConfigured_MapsThem()
+    {
+        var config = CreateConfig();
+        config.Acks = "all";
+        config.EnableIdempotence = true;
+        config.MaxInFlight = 5;
+
+        var result = config.ToProducerConfig();
+
+        Assert.Equal(Acks.All, result.Acks);
+        Assert.True(result.EnableIdempotence);
+        Assert.Equal(5, result.MaxInFlight);
+    }
+
+    [Theory]
+    [InlineData("0", Acks.None)]
+    [InlineData("1", Acks.Leader)]
+    [InlineData("-1", Acks.All)]
+    [InlineData("none", Acks.None)]
+    [InlineData("leader", Acks.Leader)]
+    [InlineData("all", Acks.All)]
+    public void ToProducerConfig_WhenAcksUsesSupportedValue_MapsIt(string value, Acks expected)
+    {
+        var config = CreateConfig();
+        config.Acks = value;
+
+        var result = config.ToProducerConfig();
+
+        Assert.Equal(expected, result.Acks);
+    }
+
+    [Theory]
+    [InlineData("invalid")]
+    [InlineData("2")]
+    public void ToProducerConfig_WhenAcksIsInvalid_ThrowsClearException(string value)
+    {
+        var config = CreateConfig();
+        config.Acks = value;
+
+        var exception = Assert.Throws<ArgumentException>(() => config.ToProducerConfig());
+
+        Assert.Contains("Unsupported Kafka producer acknowledgement value", exception.Message);
+    }
+
+    private static KafkaProducerConfig CreateConfig()
+    {
+        return new KafkaProducerConfig
+        {
+            BootstrapServers = "broker-1:9092,broker-2:9092,broker-3:9092",
+            MessageMaxBytes = 1_000_000,
+            ReceiveMessageMaxBytes = 1_000_000,
+            MessageTimeoutMs = 30_000,
+            RequestTimeoutMs = 5_000,
+            SocketTimeoutMs = 60_000,
+            SocketKeepaliveEnable = true,
+            CompressionType = "gzip",
+            CompressionLevel = 5
+        };
+    }
+}

--- a/tests/am.kon.packages.services.kafka.tests/KafkaTopicConfigReconciliationPlannerTests.cs
+++ b/tests/am.kon.packages.services.kafka.tests/KafkaTopicConfigReconciliationPlannerTests.cs
@@ -1,0 +1,137 @@
+using am.kon.packages.services.kafka.Config;
+using Confluent.Kafka.Admin;
+
+namespace am.kon.packages.services.kafka.tests;
+
+public sealed class KafkaTopicConfigReconciliationPlannerTests
+{
+    [Fact]
+    public void ReconciliationOption_WhenOmitted_PreservesCreationOnlyDefault()
+    {
+        Assert.False(new KafkaTopicManagerConfig().ReconcileExistingTopicConfigs);
+    }
+
+    [Fact]
+    public void ResolveDesiredConfigs_SelectsOnlySupportedDurabilityConfigs()
+    {
+        var desired = KafkaTopicConfigReconciliationPlanner.ResolveDesiredConfigs(
+            new Dictionary<string, string>
+            {
+                ["min.insync.replicas"] = "2",
+                ["unclean.leader.election.enable"] = "false",
+                ["cleanup.policy"] = "compact",
+            });
+
+        Assert.Equal(2, desired.Count);
+        Assert.Equal("2", desired["min.insync.replicas"]);
+        Assert.Equal("false", desired["unclean.leader.election.enable"]);
+        Assert.DoesNotContain("cleanup.policy", desired.Keys);
+    }
+
+    [Fact]
+    public void ResolveDesiredConfigs_WhenConfigsAreOmitted_ReturnsEmptyPlan()
+    {
+        Assert.Empty(KafkaTopicConfigReconciliationPlanner.ResolveDesiredConfigs(null!));
+    }
+
+    [Fact]
+    public void ResolveAlterations_WhenValuesMatch_IsIdempotent()
+    {
+        var desired = DurabilityConfigs();
+        var alterations = KafkaTopicConfigReconciliationPlanner.ResolveAlterations(
+            desired,
+            new Dictionary<string, string>
+            {
+                ["min.insync.replicas"] = "2",
+                ["unclean.leader.election.enable"] = "false",
+            });
+
+        Assert.Empty(alterations);
+    }
+
+    [Fact]
+    public void ResolveAlterations_WhenValuesDrift_UsesIncrementalSetForSupportedConfigs()
+    {
+        var alterations = KafkaTopicConfigReconciliationPlanner.ResolveAlterations(
+            DurabilityConfigs(),
+            new Dictionary<string, string>
+            {
+                ["min.insync.replicas"] = "1",
+                ["unclean.leader.election.enable"] = "true",
+            });
+
+        Assert.Equal(2, alterations.Count);
+        Assert.All(alterations, alteration => Assert.Equal(AlterConfigOpType.Set, alteration.IncrementalOperation));
+        Assert.Contains(alterations, alteration => alteration.Name == "min.insync.replicas" && alteration.Value == "2");
+        Assert.Contains(alterations, alteration => alteration.Name == "unclean.leader.election.enable" && alteration.Value == "false");
+    }
+
+    [Fact]
+    public void ResolveAlterations_WhenOneValueDrifts_ChangesOnlyThatValue()
+    {
+        var alteration = Assert.Single(KafkaTopicConfigReconciliationPlanner.ResolveAlterations(
+            DurabilityConfigs(),
+            new Dictionary<string, string>
+            {
+                ["min.insync.replicas"] = "2",
+                ["unclean.leader.election.enable"] = "true",
+            }));
+
+        Assert.Equal("unclean.leader.election.enable", alteration.Name);
+        Assert.Equal("false", alteration.Value);
+        Assert.Equal(AlterConfigOpType.Set, alteration.IncrementalOperation);
+    }
+
+    [Fact]
+    public void ResolveAlterations_WhenCurrentValueIsMissing_SetsDesiredValue()
+    {
+        var alteration = Assert.Single(KafkaTopicConfigReconciliationPlanner.ResolveAlterations(
+            new Dictionary<string, string> { ["min.insync.replicas"] = "2" },
+            new Dictionary<string, string>()));
+
+        Assert.Equal("min.insync.replicas", alteration.Name);
+        Assert.Equal("2", alteration.Value);
+    }
+
+    [Theory]
+    [InlineData("FALSE")]
+    [InlineData("False")]
+    public void ResolveAlterations_BooleanComparisonIsCanonical(string currentValue)
+    {
+        var alterations = KafkaTopicConfigReconciliationPlanner.ResolveAlterations(
+            new Dictionary<string, string> { ["unclean.leader.election.enable"] = "false" },
+            new Dictionary<string, string> { ["unclean.leader.election.enable"] = currentValue });
+
+        Assert.Empty(alterations);
+    }
+
+    [Fact]
+    public void ValidateExistingReplicationFactor_WhenMinIsrFits_DoesNotThrow()
+    {
+        KafkaTopicConfigReconciliationPlanner.ValidateExistingReplicationFactor(
+            "orders.events.v1",
+            new Dictionary<string, string> { ["min.insync.replicas"] = "2" },
+            3);
+    }
+
+    [Fact]
+    public void ValidateExistingReplicationFactor_WhenMinIsrExceedsLiveReplication_ThrowsWithoutPlan()
+    {
+        var exception = Assert.Throws<InvalidOperationException>(() =>
+            KafkaTopicConfigReconciliationPlanner.ValidateExistingReplicationFactor(
+                "orders.events.v1",
+                new Dictionary<string, string> { ["min.insync.replicas"] = "3" },
+                2));
+
+        Assert.Contains("does not change replica assignments", exception.Message);
+    }
+
+    private static Dictionary<string, string> DurabilityConfigs()
+    {
+        return new Dictionary<string, string>
+        {
+            ["min.insync.replicas"] = "2",
+            ["unclean.leader.election.enable"] = "false",
+        };
+    }
+}

--- a/tests/am.kon.packages.services.kafka.tests/KafkaTopicSpecificationResolverTests.cs
+++ b/tests/am.kon.packages.services.kafka.tests/KafkaTopicSpecificationResolverTests.cs
@@ -207,6 +207,44 @@ public sealed class KafkaTopicSpecificationResolverTests
     }
 
     [Fact]
+    public void Resolve_WhenDurabilityValuesUseNonCanonicalForms_NormalizesThem()
+    {
+        var config = CreateConfig();
+        config.EnsureExistTopics = ["orders.events.v1"];
+        config.TopicConfigsDefault = new Dictionary<string, string>
+        {
+            ["MIN.INSYNC.REPLICAS"] = "+2",
+            ["UNCLEAN.LEADER.ELECTION.ENABLE"] = "False",
+        };
+
+        var topic = Assert.Single(KafkaTopicSpecificationResolver.Resolve(config));
+
+        Assert.Equal("2", topic.Configs!["min.insync.replicas"]);
+        Assert.Equal("false", topic.Configs["unclean.leader.election.enable"]);
+        Assert.Contains("min.insync.replicas", topic.Configs.Keys);
+        Assert.Contains("unclean.leader.election.enable", topic.Configs.Keys);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("enabled")]
+    [InlineData("0")]
+    public void Resolve_WhenUncleanLeaderElectionValueIsInvalid_Throws(string value)
+    {
+        var config = CreateConfig();
+        config.EnsureExistTopics = ["orders.events.v1"];
+        config.TopicConfigsDefault = new Dictionary<string, string>
+        {
+            ["unclean.leader.election.enable"] = value,
+        };
+
+        var exception = Assert.Throws<ArgumentException>(
+            () => KafkaTopicSpecificationResolver.Resolve(config));
+
+        Assert.Contains("invalid unclean.leader.election.enable", exception.Message);
+    }
+
+    [Fact]
     public void Resolve_WhenDetailedSpecificationIsDuplicated_ThrowsDuplicateError()
     {
         var config = CreateConfig();

--- a/tests/am.kon.packages.services.kafka.tests/KafkaTopicSpecificationResolverTests.cs
+++ b/tests/am.kon.packages.services.kafka.tests/KafkaTopicSpecificationResolverTests.cs
@@ -1,0 +1,347 @@
+using am.kon.packages.services.kafka.Config;
+
+namespace am.kon.packages.services.kafka.tests;
+
+public sealed class KafkaTopicSpecificationResolverTests
+{
+    [Fact]
+    public void Resolve_WhenLegacyTopicsAreConfigured_UsesDefaultsAndDefaultConfigs()
+    {
+        var config = CreateConfig();
+        config.EnsureExistTopics = [" orders.events.v1 "];
+        config.TopicConfigsDefault = new Dictionary<string, string>
+        {
+            ["min.insync.replicas"] = "2",
+            ["unclean.leader.election.enable"] = "false"
+        };
+
+        var result = KafkaTopicSpecificationResolver.Resolve(config);
+
+        var topic = Assert.Single(result);
+        Assert.Equal("orders.events.v1", topic.Name);
+        Assert.Equal(3, topic.NumPartitions);
+        Assert.Equal((short)3, topic.ReplicationFactor);
+        Assert.Equal("2", topic.Configs!["min.insync.replicas"]);
+        Assert.Equal("false", topic.Configs["unclean.leader.election.enable"]);
+    }
+
+    [Fact]
+    public void Resolve_WhenLegacyTopicsContainDuplicates_PreservesLegacyDeduplication()
+    {
+        var config = CreateConfig();
+        config.EnsureExistTopics = ["orders.events.v1", " ORDERS.EVENTS.V1 ", "", "  "];
+
+        var result = KafkaTopicSpecificationResolver.Resolve(config);
+
+        Assert.Single(result);
+        Assert.Equal("orders.events.v1", result[0].Name);
+    }
+
+    [Fact]
+    public void Resolve_WhenDetailedTopicIsConfigured_AppliesOverridesAndMergesConfigs()
+    {
+        var config = CreateConfig();
+        config.TopicConfigsDefault = new Dictionary<string, string>
+        {
+            ["min.insync.replicas"] = "2",
+            ["cleanup.policy"] = "delete"
+        };
+        config.EnsureExistTopicSpecifications =
+        [
+            new KafkaTopicCreationConfig
+            {
+                Name = "orders.compacted.v1",
+                NumPartitions = 6,
+                ReplicationFactor = 3,
+                Configs = new Dictionary<string, string>
+                {
+                    ["cleanup.policy"] = "compact"
+                }
+            }
+        ];
+
+        var result = KafkaTopicSpecificationResolver.Resolve(config);
+
+        var topic = Assert.Single(result);
+        Assert.Equal(6, topic.NumPartitions);
+        Assert.Equal((short)3, topic.ReplicationFactor);
+        Assert.Equal("2", topic.Configs!["min.insync.replicas"]);
+        Assert.Equal("compact", topic.Configs["cleanup.policy"]);
+    }
+
+    [Fact]
+    public void Resolve_WhenDetailedValuesAreOmitted_FallsBackToSectionDefaults()
+    {
+        var config = CreateConfig();
+        config.EnsureExistTopicSpecifications =
+        [
+            new KafkaTopicCreationConfig { Name = "orders.events.v1" }
+        ];
+
+        var topic = Assert.Single(KafkaTopicSpecificationResolver.Resolve(config));
+
+        Assert.Equal(3, topic.NumPartitions);
+        Assert.Equal((short)3, topic.ReplicationFactor);
+    }
+
+    [Fact]
+    public void Resolve_WhenDetailedTopicMatchesLegacyTopic_UsesDetailedDefinitionOnce()
+    {
+        var config = CreateConfig();
+        config.EnsureExistTopics = ["orders.events.v1"];
+        config.EnsureExistTopicSpecifications =
+        [
+            new KafkaTopicCreationConfig
+            {
+                Name = "ORDERS.EVENTS.V1",
+                NumPartitions = 6,
+                ReplicationFactor = 3
+            }
+        ];
+
+        var topic = Assert.Single(KafkaTopicSpecificationResolver.Resolve(config));
+
+        Assert.Equal("ORDERS.EVENTS.V1", topic.Name);
+        Assert.Equal(6, topic.NumPartitions);
+    }
+
+    [Fact]
+    public void Resolve_WhenNoTopicsAreConfigured_PreservesEmptyLegacyBehavior()
+    {
+        var config = new KafkaTopicManagerConfig();
+
+        var result = KafkaTopicSpecificationResolver.Resolve(config);
+
+        Assert.Empty(result);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void Resolve_WhenPartitionCountIsNotPositive_Throws(int partitionCount)
+    {
+        var config = CreateConfig();
+        config.EnsureExistTopicSpecifications =
+        [
+            new KafkaTopicCreationConfig
+            {
+                Name = "orders.events.v1",
+                NumPartitions = partitionCount,
+                ReplicationFactor = 3
+            }
+        ];
+
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(
+            () => KafkaTopicSpecificationResolver.Resolve(config));
+
+        Assert.Contains("positive partition count", exception.Message);
+    }
+
+    [Theory]
+    [InlineData((short)0)]
+    [InlineData((short)-1)]
+    public void Resolve_WhenReplicationFactorIsNotPositive_Throws(short replicationFactor)
+    {
+        var config = CreateConfig();
+        config.EnsureExistTopicSpecifications =
+        [
+            new KafkaTopicCreationConfig
+            {
+                Name = "orders.events.v1",
+                NumPartitions = 3,
+                ReplicationFactor = replicationFactor
+            }
+        ];
+
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(
+            () => KafkaTopicSpecificationResolver.Resolve(config));
+
+        Assert.Contains("positive replication factor", exception.Message);
+    }
+
+    [Fact]
+    public void Resolve_WhenLegacyTopicUsesInvalidDefaults_Throws()
+    {
+        var config = CreateConfig();
+        config.EnsureExistTopics = ["orders.events.v1"];
+        config.NumPartitionsDefault = 0;
+
+        var exception = Assert.Throws<ArgumentOutOfRangeException>(
+            () => KafkaTopicSpecificationResolver.Resolve(config));
+
+        Assert.Contains("positive partition count", exception.Message);
+    }
+
+    [Fact]
+    public void Resolve_WhenMinInSyncReplicasExceedsReplicationFactor_Throws()
+    {
+        var config = CreateConfig();
+        config.EnsureExistTopics = ["orders.events.v1"];
+        config.TopicConfigsDefault = new Dictionary<string, string>
+        {
+            ["min.insync.replicas"] = "4"
+        };
+
+        var exception = Assert.Throws<ArgumentException>(
+            () => KafkaTopicSpecificationResolver.Resolve(config));
+
+        Assert.Contains("exceeds replication factor 3", exception.Message);
+    }
+
+    [Theory]
+    [InlineData("0")]
+    [InlineData("not-an-integer")]
+    public void Resolve_WhenMinInSyncReplicasIsInvalid_Throws(string value)
+    {
+        var config = CreateConfig();
+        config.EnsureExistTopics = ["orders.events.v1"];
+        config.TopicConfigsDefault = new Dictionary<string, string>
+        {
+            ["min.insync.replicas"] = value
+        };
+
+        var exception = Assert.Throws<ArgumentException>(
+            () => KafkaTopicSpecificationResolver.Resolve(config));
+
+        Assert.Contains("invalid min.insync.replicas", exception.Message);
+    }
+
+    [Fact]
+    public void Resolve_WhenDetailedSpecificationIsDuplicated_ThrowsDuplicateError()
+    {
+        var config = CreateConfig();
+        config.EnsureExistTopicSpecifications =
+        [
+            new KafkaTopicCreationConfig { Name = "orders.events.v1" },
+            new KafkaTopicCreationConfig { Name = "ORDERS.EVENTS.V1" }
+        ];
+
+        var exception = Assert.Throws<ArgumentException>(
+            () => KafkaTopicSpecificationResolver.Resolve(config));
+
+        Assert.Contains("Duplicate detailed Kafka topic specification", exception.Message);
+    }
+
+    [Fact]
+    public void Resolve_WhenDetailedSpecificationsConflict_ThrowsConflictError()
+    {
+        var config = CreateConfig();
+        config.EnsureExistTopicSpecifications =
+        [
+            new KafkaTopicCreationConfig { Name = "orders.events.v1", NumPartitions = 3 },
+            new KafkaTopicCreationConfig { Name = "orders.events.v1", NumPartitions = 6 }
+        ];
+
+        var exception = Assert.Throws<ArgumentException>(
+            () => KafkaTopicSpecificationResolver.Resolve(config));
+
+        Assert.Contains("Conflicting detailed Kafka topic specification", exception.Message);
+    }
+
+    [Fact]
+    public void Resolve_WhenDetailedTopicNameIsEmpty_Throws()
+    {
+        var config = CreateConfig();
+        config.EnsureExistTopicSpecifications =
+        [
+            new KafkaTopicCreationConfig { Name = " " }
+        ];
+
+        var exception = Assert.Throws<ArgumentException>(
+            () => KafkaTopicSpecificationResolver.Resolve(config));
+
+        Assert.Contains("non-empty topic name", exception.Message);
+    }
+
+    [Fact]
+    public void Resolve_WhenConfigKeyIsEmpty_Throws()
+    {
+        var config = CreateConfig();
+        config.EnsureExistTopics = ["orders.events.v1"];
+        config.TopicConfigsDefault = new Dictionary<string, string> { [" "] = "value" };
+
+        var exception = Assert.Throws<ArgumentException>(
+            () => KafkaTopicSpecificationResolver.Resolve(config));
+
+        Assert.Contains("empty Kafka config key", exception.Message);
+    }
+
+    [Fact]
+    public void Resolve_WhenConfigKeysConflictByCase_Throws()
+    {
+        var config = CreateConfig();
+        config.EnsureExistTopics = ["orders.events.v1"];
+        config.TopicConfigsDefault = new Dictionary<string, string>
+        {
+            ["cleanup.policy"] = "delete",
+            ["CLEANUP.POLICY"] = "compact"
+        };
+
+        var exception = Assert.Throws<ArgumentException>(
+            () => KafkaTopicSpecificationResolver.Resolve(config));
+
+        Assert.Contains("conflicting values for Kafka config", exception.Message);
+    }
+
+    [Fact]
+    public void Resolve_WhenConfigValueIsNull_Throws()
+    {
+        var config = CreateConfig();
+        config.EnsureExistTopics = ["orders.events.v1"];
+        config.TopicConfigsDefault = new Dictionary<string, string>
+        {
+            ["cleanup.policy"] = null!
+        };
+
+        var exception = Assert.Throws<ArgumentException>(
+            () => KafkaTopicSpecificationResolver.Resolve(config));
+
+        Assert.Contains("has a null value", exception.Message);
+    }
+
+    [Fact]
+    public void Resolve_WhenTopicOverridesDefaultMinInSyncReplicas_ValidatesResolvedValue()
+    {
+        var config = CreateConfig();
+        config.TopicConfigsDefault = new Dictionary<string, string>
+        {
+            ["min.insync.replicas"] = "4"
+        };
+        config.EnsureExistTopicSpecifications =
+        [
+            new KafkaTopicCreationConfig
+            {
+                Name = "orders.events.v1",
+                Configs = new Dictionary<string, string>
+                {
+                    ["min.insync.replicas"] = "2"
+                }
+            }
+        ];
+
+        var topic = Assert.Single(KafkaTopicSpecificationResolver.Resolve(config));
+
+        Assert.Equal("2", topic.Configs!["min.insync.replicas"]);
+    }
+
+    [Fact]
+    public void Resolve_WhenDetailedSpecificationEntryIsNull_Throws()
+    {
+        var config = CreateConfig();
+        config.EnsureExistTopicSpecifications = [null!];
+
+        var exception = Assert.Throws<ArgumentException>(
+            () => KafkaTopicSpecificationResolver.Resolve(config));
+
+        Assert.Contains("cannot contain null entries", exception.Message);
+    }
+
+    private static KafkaTopicManagerConfig CreateConfig()
+    {
+        return new KafkaTopicManagerConfig
+        {
+            NumPartitionsDefault = 3,
+            ReplicationFactorDefault = 3
+        };
+    }
+}

--- a/tests/am.kon.packages.services.kafka.tests/am.kon.packages.services.kafka.tests.csproj
+++ b/tests/am.kon.packages.services.kafka.tests/am.kon.packages.services.kafka.tests.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <OutputType>Exe</OutputType>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="xunit.v3.mtp-v2" Version="3.2.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../src/am.kon.packages.services.kafka.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/am.kon.packages.services.kafka.tests/xunit.runner.json
+++ b/tests/am.kon.packages.services.kafka.tests/xunit.runner.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
+  "parallelizeAssembly": true,
+  "parallelizeTestCollections": true,
+  "maxParallelThreads": 0,
+  "parallelAlgorithm": "aggressive",
+  "diagnosticMessages": false
+}


### PR DESCRIPTION
## Release

Publish `am.kon.packages.services.kafka` `0.1.0.10` from the current reviewed `main` branch.

## Included capability

- explicit optional consumer `AutoOffsetReset` mapping, including `Error`
- optional durable producer settings
- safe per-topic creation configuration and existing-topic durability reconciliation
- backward compatibility when new settings are omitted

## Validation

- main PR #10 merged with build and GitGuardian checks green
- Release build passed with warnings as errors
- 51/51 tests passed
- package `0.1.0.10` packed and inspected locally
- NuGet currently exposes `0.1.0.9`; `0.1.0.10` is not present before this PR
- release/main merge-tree is conflict-free and release has no unique file content

## Publication behavior

The release-target workflow publishes to NuGet during this pull request. The post-merge push uses `--skip-duplicate`.

Jira: https://spolith.atlassian.net/browse/SL-4664