### PR TITLE
SL-4664 expose Kafka offset-expiry telemetry hook

### DIFF
--- a/src/KafkaConsumeExceptionClassifier.cs
+++ b/src/KafkaConsumeExceptionClassifier.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using Confluent.Kafka;
+
+namespace am.kon.packages.services.kafka
+{
+    internal static class KafkaConsumeExceptionClassifier
+    {
+        internal static bool IsAutoOffsetResetError(Exception exception)
+        {
+            return exception is ConsumeException consumeException
+                && consumeException.Error.Code == ErrorCode.Local_AutoOffsetReset;
+        }
+    }
+}

--- a/src/KafkaDataConsumerService.cs
+++ b/src/KafkaDataConsumerService.cs
@@ -35,9 +35,25 @@ namespace am.kon.packages.services.kafka
 
         private readonly KafkaTopicManagerService _kafkaTopicManagerService;
 
+        private Action _autoOffsetResetErrorHandler;
+
         protected int _disposed;
 
         protected Func<Message<TKey, TValue>, Task<bool>> ProcessMessageAsync { get; set; }
+
+        /// <summary>
+        /// Sets the callback invoked when Confluent.Kafka reports that the configured
+        /// offset reset policy cannot resolve an unavailable committed offset.
+        /// A subsequent call replaces the previous callback; passing <c>null</c> disables it.
+        /// </summary>
+        /// <param name="handler">
+        /// Synchronous, non-blocking callback invoked once for each
+        /// <see cref="ErrorCode.Local_AutoOffsetReset"/> consume error.
+        /// </param>
+        protected void SetAutoOffsetResetErrorHandler(Action handler)
+        {
+            _autoOffsetResetErrorHandler = handler;
+        }
 
         public KafkaDataConsumerService(
             ILogger<KafkaDataConsumerService<TKey, TValue>> logger,
@@ -135,7 +151,7 @@ namespace am.kon.packages.services.kafka
                         // if AutoCommit is enabled there is no need to coll _consumer.Commit
                         bool commitConsume = !_kafkaConsumerConfig.AutoCommit;
 
-                        if(ProcessMessageAsync == null)
+                        if (ProcessMessageAsync == null)
                         {
                             _messagesQueue.Enqueue(consumeResult.Message);
                             Interlocked.Increment(ref _messagesQueueLength);
@@ -158,6 +174,7 @@ namespace am.kon.packages.services.kafka
                     }
                     catch (Exception ex)
                     {
+                        NotifyAutoOffsetResetError(ex);
                         _logger.LogError(ex, $"Consume error. ClientID: {_consumer.Name}");
                     }
                 }
@@ -169,6 +186,27 @@ namespace am.kon.packages.services.kafka
             finally
             {
                 Interlocked.Exchange(ref _consumingIsInProgress, 0);
+            }
+        }
+
+        private void NotifyAutoOffsetResetError(Exception exception)
+        {
+            if (!KafkaConsumeExceptionClassifier.IsAutoOffsetResetError(exception))
+                return;
+
+            Action handler = _autoOffsetResetErrorHandler;
+            if (handler == null)
+                return;
+
+            try
+            {
+                handler();
+            }
+            catch (Exception callbackException)
+            {
+                _logger.LogWarning(
+                    callbackException,
+                    "Kafka auto-offset-reset error telemetry callback failed.");
             }
         }
 
@@ -199,12 +237,12 @@ namespace am.kon.packages.services.kafka
         /// </summary>
         protected virtual void Dispose(bool disposing)
         {
-            if(!disposing)
+            if (!disposing)
                 return;
 
             int originalValue = Interlocked.CompareExchange(ref _disposed, 1, 0);
 
-            if(originalValue != 0)
+            if (originalValue != 0)
                 return;
 
             _consumer?.Dispose();
@@ -222,4 +260,3 @@ namespace am.kon.packages.services.kafka
         }
     }
 }
-

--- a/tests/am.kon.packages.services.kafka.tests/KafkaConsumeExceptionClassifierTests.cs
+++ b/tests/am.kon.packages.services.kafka.tests/KafkaConsumeExceptionClassifierTests.cs
@@ -1,0 +1,41 @@
+using Confluent.Kafka;
+
+namespace am.kon.packages.services.kafka.tests;
+
+public sealed class KafkaConsumeExceptionClassifierTests
+{
+    [Fact]
+    public void IsAutoOffsetResetError_WhenConsumeErrorIsLocalAutoOffsetReset_ReturnsTrue()
+    {
+        var exception = CreateConsumeException(ErrorCode.Local_AutoOffsetReset);
+
+        var result = KafkaConsumeExceptionClassifier.IsAutoOffsetResetError(exception);
+
+        Assert.True(result);
+    }
+
+    [Theory]
+    [InlineData(ErrorCode.Local_Application)]
+    [InlineData(ErrorCode.OffsetOutOfRange)]
+    public void IsAutoOffsetResetError_WhenConsumeErrorHasDifferentCode_ReturnsFalse(ErrorCode errorCode)
+    {
+        var exception = CreateConsumeException(errorCode);
+
+        var result = KafkaConsumeExceptionClassifier.IsAutoOffsetResetError(exception);
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void IsAutoOffsetResetError_WhenExceptionIsNotConsumeException_ReturnsFalse()
+    {
+        var result = KafkaConsumeExceptionClassifier.IsAutoOffsetResetError(new InvalidOperationException());
+
+        Assert.False(result);
+    }
+
+    private static ConsumeException CreateConsumeException(ErrorCode errorCode)
+    {
+        return new ConsumeException(null, new Error(errorCode));
+    }
+}


### PR DESCRIPTION
## Context

SL-4664 configures consumers with `AutoOffsetReset=Error` so an expired committed offset fails closed. The shared wrapper currently logs that consume error but gives a service no bounded way to export an operational metric or fail readiness.

## Changes

- add a protected single-handler hook for `Local_AutoOffsetReset` consume errors;
- classify only direct `ConsumeException` values with that exact Confluent error code;
- isolate callback failures so existing consume-loop behavior remains unchanged;
- add focused MTP/xUnit v3 classifier tests.

The package stays on unpublished version `0.1.0.10`; NuGet currently ends at `0.1.0.9`.

## Compatibility

- no new package dependency;
- no behavior change when no handler is registered;
- later registration replaces the prior handler; null disables it;
- the original consume exception is still logged and handled by the existing loop.

## Validation

- Release build with warnings as errors;
- 55/55 tests passed;
- touched-file formatting and diff checks passed.

Jira: https://spolith.atlassian.net/browse/SL-4664