### PR TITLE
fix: align release test and pack configurations

### DIFF
--- a/.github/workflows/dotnet-beta-release.yml
+++ b/.github/workflows/dotnet-beta-release.yml
@@ -25,9 +25,9 @@ jobs:
     - name: Build
       run: dotnet build --no-restore --configuration Release
     - name: Test
-      run: dotnet test --no-build --verbosity normal
+      run: dotnet test --no-build --configuration Release --verbosity normal
     - name: Pack
-      run: dotnet pack --output ./packages --no-build --no-restore
+      run: dotnet pack --output ./packages --no-build --no-restore --configuration Release
     - name: Push
       env:
         api_secret: ${{ secrets.NUGET_PUBLISH_SECRET }}


### PR DESCRIPTION
## Summary

- add `--configuration Release` to the release workflow Test step
- add `--configuration Release` to the release workflow Pack step
- keep the change limited to the failing GitHub Actions workflow

## Root cause

The workflow builds Release artifacts, then runs Test and Pack with their default Debug configuration while also passing `--no-build`. The Test step therefore looks for a Debug test executable that was never built, reports zero tests, and prevents Pack/Push from running.

## Impact

Test and Pack now consume the same Release artifacts produced by Build. No package source code or runtime behavior changes.

## Validation

- workflow YAML validation passed
- `dotnet restore`
- `dotnet build --no-restore --configuration Release` — 0 warnings, 0 errors
- `dotnet test --no-build --configuration Release --verbosity normal` — 55/55 passed
- `dotnet pack --output <temp> --no-build --no-restore --configuration Release` — produced `am.kon.packages.services.kafka.0.1.0.10.nupkg`

Jira: https://spolith.atlassian.net/browse/SL-4664